### PR TITLE
replaced Fmask with QA for S30

### DIFF
--- a/hls_hdf_to_cog/hls_hdf_to_cog.py
+++ b/hls_hdf_to_cog/hls_hdf_to_cog.py
@@ -48,7 +48,7 @@ S30_BAND_NAMES = (
     "B10",
     "B11",
     "B12",
-    "Fmask",
+    "QA",
 )
 
 S30_DEBUG_BAND_NAMES = (
@@ -66,7 +66,7 @@ S30_DEBUG_BAND_NAMES = (
     "B11",
     "B12",
     "ACmask",
-    "Fmask",
+    "QA",
 )
 
 ANGLE_BAND_NAMES = {


### PR DESCRIPTION
The S30 product doesn't have a `Fmask` band and the QA band is named `QA`. I replaced this in `S30_BAND_NAMES` and `S30_DEBUG_BAND_NAMES`.
